### PR TITLE
re-add missing global session variable

### DIFF
--- a/lib/Basic.php
+++ b/lib/Basic.php
@@ -90,7 +90,7 @@ class Passwd_Basic
      */
     private function _init()
     {
-        global $conf, $page_output;
+        global $conf, $page_output, $session;
         $passedToken = $this->_vars->get('token', '');
         $sessionToken = $GLOBALS['session']->getToken();
 


### PR DESCRIPTION
Fixes "Call to a member function getToken() on null" when trying to access the page for the changing passwords.